### PR TITLE
Update META to current working standard

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -4,7 +4,7 @@
     "license" : "Artistic-2.0",
     "tags": ["Web", "API"],
     "version" : "0.0.1",
-    "author" : "github:dboys",
+    "authors" : ["github:dboys"],
     "description" : "Perl6 client for the Silver Gold Bull(https://silvergoldbull.com) web service",
     "depends" : [ "URI", "HTTP::UserAgent", "JSON::Fast" ],
     "provides" : {


### PR DESCRIPTION
Only `authors` key that has an array is currently allowed. There's no standard `author` key.